### PR TITLE
[FEAT] JWT 기반 카카오 소셜 로그인 구현 및 개선

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,15 @@ dependencies {
 	implementation 'org.redisson:redisson:3.27.2'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+	// Spring Security + OAuth2
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
+	// JWT
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.5'
+
 	// Database
 	runtimeOnly 'com.mysql:mysql-connector-j'
 
@@ -50,6 +59,7 @@ dependencies {
 
 	// Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
 	// Testcontainers

--- a/src/main/java/PetMoa/PetMoa/domain/auth/controller/AuthController.java
+++ b/src/main/java/PetMoa/PetMoa/domain/auth/controller/AuthController.java
@@ -1,10 +1,10 @@
 package PetMoa.PetMoa.domain.auth.controller;
 
 import PetMoa.PetMoa.domain.auth.service.AuthService;
-import PetMoa.PetMoa.domain.user.entity.User;
 import PetMoa.PetMoa.global.apiPayload.ApiResponse;
 import PetMoa.PetMoa.global.security.CurrentUser;
 import PetMoa.PetMoa.global.security.jwt.CookieUtils;
+import PetMoa.PetMoa.global.security.jwt.JwtUserPrincipal;
 import PetMoa.PetMoa.global.security.jwt.TokenResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -50,10 +50,10 @@ public class AuthController {
     @Operation(summary = "로그아웃", description = "Refresh Token을 삭제하고 쿠키를 제거합니다.")
     @PostMapping("/logout")
     public ApiResponse<Void> logout(
-            @CurrentUser User user,
+            @CurrentUser JwtUserPrincipal principal,
             HttpServletResponse response) {
         // Redis에서 Refresh Token 삭제
-        authService.logout(user.getId());
+        authService.logout(principal.getId());
 
         // 쿠키 삭제
         cookieUtils.deleteAllAuthCookies(response);

--- a/src/main/java/PetMoa/PetMoa/domain/auth/controller/AuthController.java
+++ b/src/main/java/PetMoa/PetMoa/domain/auth/controller/AuthController.java
@@ -1,14 +1,15 @@
 package PetMoa.PetMoa.domain.auth.controller;
 
-import PetMoa.PetMoa.domain.auth.dto.TokenRefreshRequest;
 import PetMoa.PetMoa.domain.auth.service.AuthService;
 import PetMoa.PetMoa.domain.user.entity.User;
 import PetMoa.PetMoa.global.apiPayload.ApiResponse;
 import PetMoa.PetMoa.global.security.CurrentUser;
+import PetMoa.PetMoa.global.security.jwt.CookieUtils;
 import PetMoa.PetMoa.global.security.jwt.TokenResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -19,6 +20,7 @@ import org.springframework.web.bind.annotation.*;
 public class AuthController {
 
     private final AuthService authService;
+    private final CookieUtils cookieUtils;
 
     @Operation(summary = "카카오 로그인 URL", description = "카카오 OAuth2 로그인 URL을 반환합니다.")
     @GetMapping("/kakao/login-url")
@@ -26,18 +28,36 @@ public class AuthController {
         return ApiResponse.onSuccess("/oauth2/authorization/kakao");
     }
 
-    @Operation(summary = "토큰 갱신", description = "Refresh Token으로 새로운 Access Token을 발급합니다.")
+    @Operation(summary = "토큰 갱신", description = "쿠키의 Refresh Token으로 새로운 토큰을 발급합니다.")
     @PostMapping("/refresh")
-    public ApiResponse<TokenResponse> refreshToken(
-            @Valid @RequestBody TokenRefreshRequest request) {
-        TokenResponse tokenResponse = authService.refreshToken(request.refreshToken());
-        return ApiResponse.onSuccess(tokenResponse);
+    public ApiResponse<Void> refreshToken(
+            HttpServletRequest request,
+            HttpServletResponse response) {
+        // 쿠키에서 Refresh Token 추출
+        String refreshToken = cookieUtils.getCookieValue(request, CookieUtils.REFRESH_TOKEN_COOKIE)
+                .orElseThrow(() -> new IllegalArgumentException("Refresh Token이 없습니다."));
+
+        // 토큰 갱신
+        TokenResponse tokenResponse = authService.refreshToken(refreshToken);
+
+        // 새 토큰을 쿠키로 설정
+        cookieUtils.addAccessTokenCookie(response, tokenResponse.accessToken());
+        cookieUtils.addRefreshTokenCookie(response, tokenResponse.refreshToken());
+
+        return ApiResponse.onSuccess(null);
     }
 
-    @Operation(summary = "로그아웃", description = "현재 사용자의 Refresh Token을 삭제합니다.")
+    @Operation(summary = "로그아웃", description = "Refresh Token을 삭제하고 쿠키를 제거합니다.")
     @PostMapping("/logout")
-    public ApiResponse<Void> logout(@CurrentUser User user) {
+    public ApiResponse<Void> logout(
+            @CurrentUser User user,
+            HttpServletResponse response) {
+        // Redis에서 Refresh Token 삭제
         authService.logout(user.getId());
+
+        // 쿠키 삭제
+        cookieUtils.deleteAllAuthCookies(response);
+
         return ApiResponse.onSuccess(null);
     }
 }

--- a/src/main/java/PetMoa/PetMoa/domain/auth/controller/AuthController.java
+++ b/src/main/java/PetMoa/PetMoa/domain/auth/controller/AuthController.java
@@ -1,0 +1,43 @@
+package PetMoa.PetMoa.domain.auth.controller;
+
+import PetMoa.PetMoa.domain.auth.dto.TokenRefreshRequest;
+import PetMoa.PetMoa.domain.auth.service.AuthService;
+import PetMoa.PetMoa.domain.user.entity.User;
+import PetMoa.PetMoa.global.apiPayload.ApiResponse;
+import PetMoa.PetMoa.global.security.CurrentUser;
+import PetMoa.PetMoa.global.security.jwt.TokenResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Auth", description = "인증 API")
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @Operation(summary = "카카오 로그인 URL", description = "카카오 OAuth2 로그인 URL을 반환합니다.")
+    @GetMapping("/kakao/login-url")
+    public ApiResponse<String> getKakaoLoginUrl() {
+        return ApiResponse.onSuccess("/oauth2/authorization/kakao");
+    }
+
+    @Operation(summary = "토큰 갱신", description = "Refresh Token으로 새로운 Access Token을 발급합니다.")
+    @PostMapping("/refresh")
+    public ApiResponse<TokenResponse> refreshToken(
+            @Valid @RequestBody TokenRefreshRequest request) {
+        TokenResponse tokenResponse = authService.refreshToken(request.refreshToken());
+        return ApiResponse.onSuccess(tokenResponse);
+    }
+
+    @Operation(summary = "로그아웃", description = "현재 사용자의 Refresh Token을 삭제합니다.")
+    @PostMapping("/logout")
+    public ApiResponse<Void> logout(@CurrentUser User user) {
+        authService.logout(user.getId());
+        return ApiResponse.onSuccess(null);
+    }
+}

--- a/src/main/java/PetMoa/PetMoa/domain/auth/dto/TokenRefreshRequest.java
+++ b/src/main/java/PetMoa/PetMoa/domain/auth/dto/TokenRefreshRequest.java
@@ -1,0 +1,9 @@
+package PetMoa.PetMoa.domain.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record TokenRefreshRequest(
+        @NotBlank(message = "Refresh Token은 필수입니다.")
+        String refreshToken
+) {
+}

--- a/src/main/java/PetMoa/PetMoa/domain/auth/service/AuthService.java
+++ b/src/main/java/PetMoa/PetMoa/domain/auth/service/AuthService.java
@@ -1,0 +1,71 @@
+package PetMoa.PetMoa.domain.auth.service;
+
+import PetMoa.PetMoa.domain.user.entity.User;
+import PetMoa.PetMoa.domain.user.repository.UserRepository;
+import PetMoa.PetMoa.global.exception.UnauthorizedException;
+import PetMoa.PetMoa.global.security.jwt.JwtTokenProvider;
+import PetMoa.PetMoa.global.security.jwt.RefreshTokenService;
+import PetMoa.PetMoa.global.security.jwt.TokenResponse;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AuthService {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenService refreshTokenService;
+    private final UserRepository userRepository;
+
+    /**
+     * Refresh Token으로 새로운 Access Token 발급
+     * Refresh Token Rotation 적용 (새로운 Refresh Token도 함께 발급)
+     */
+    public TokenResponse refreshToken(String refreshToken) {
+        // 1. Refresh Token 유효성 검증
+        if (!jwtTokenProvider.validateToken(refreshToken)) {
+            throw new UnauthorizedException("유효하지 않은 Refresh Token입니다.");
+        }
+
+        // 2. Refresh Token에서 사용자 ID 추출
+        Long userId = jwtTokenProvider.getUserIdFromToken(refreshToken);
+
+        // 3. Redis에 저장된 Refresh Token과 비교
+        if (!refreshTokenService.validateRefreshToken(userId, refreshToken)) {
+            throw new UnauthorizedException("Refresh Token이 일치하지 않습니다.");
+        }
+
+        // 4. 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));
+
+        // 5. 새로운 토큰 발급
+        String newAccessToken = jwtTokenProvider.createAccessToken(user);
+        String newRefreshToken = jwtTokenProvider.createRefreshToken(user);
+
+        // 6. 새로운 Refresh Token을 Redis에 저장 (Rotation)
+        refreshTokenService.saveRefreshToken(userId, newRefreshToken);
+
+        log.info("Token refreshed for userId: {}", userId);
+
+        return TokenResponse.of(
+                newAccessToken,
+                newRefreshToken,
+                jwtTokenProvider.getAccessTokenExpiry()
+        );
+    }
+
+    /**
+     * 로그아웃 - Refresh Token 삭제
+     */
+    @Transactional
+    public void logout(Long userId) {
+        refreshTokenService.deleteRefreshToken(userId);
+        log.info("User logged out - userId: {}", userId);
+    }
+}

--- a/src/main/java/PetMoa/PetMoa/domain/payment/controller/PaymentController.java
+++ b/src/main/java/PetMoa/PetMoa/domain/payment/controller/PaymentController.java
@@ -7,9 +7,9 @@ import PetMoa.PetMoa.domain.payment.dto.RefundRequest;
 import PetMoa.PetMoa.domain.payment.entity.Payment;
 import PetMoa.PetMoa.domain.payment.service.PaymentQueryService;
 import PetMoa.PetMoa.domain.payment.service.PaymentService;
-import PetMoa.PetMoa.domain.user.entity.User;
 import PetMoa.PetMoa.global.apiPayload.ApiResponse;
 import PetMoa.PetMoa.global.security.CurrentUser;
+import PetMoa.PetMoa.global.security.jwt.JwtUserPrincipal;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -28,55 +28,55 @@ public class PaymentController {
     @Operation(summary = "결제 요청 생성", description = "예약에 대한 결제 요청을 생성하고 orderId를 발급합니다.")
     @PostMapping
     public ApiResponse<PaymentResponse> createPayment(
-            @CurrentUser User user,
+            @CurrentUser JwtUserPrincipal principal,
             @Valid @RequestBody PaymentCreateRequest request) {
-        Payment payment = paymentService.createPayment(user.getId(), request);
+        Payment payment = paymentService.createPayment(principal.getId(), request);
         return ApiResponse.onSuccess(PaymentResponse.from(payment));
     }
 
     @Operation(summary = "결제 승인", description = "토스페이먼츠 결제 승인을 처리합니다. 클라이언트에서 결제 완료 후 호출합니다.")
     @PostMapping("/confirm")
     public ApiResponse<PaymentResponse> confirmPayment(
-            @CurrentUser User user,
+            @CurrentUser JwtUserPrincipal principal,
             @Valid @RequestBody PaymentConfirmRequest request) {
-        Payment payment = paymentService.confirmPayment(user.getId(), request);
+        Payment payment = paymentService.confirmPayment(principal.getId(), request);
         return ApiResponse.onSuccess(PaymentResponse.from(payment));
     }
 
     @Operation(summary = "결제 조회", description = "결제 상세 정보를 조회합니다.")
     @GetMapping("/{paymentId}")
     public ApiResponse<PaymentResponse> getPayment(
-            @CurrentUser User user,
+            @CurrentUser JwtUserPrincipal principal,
             @PathVariable Long paymentId) {
-        Payment payment = paymentQueryService.getPaymentById(paymentId, user.getId());
+        Payment payment = paymentQueryService.getPaymentById(paymentId, principal.getId());
         return ApiResponse.onSuccess(PaymentResponse.from(payment));
     }
 
     @Operation(summary = "주문 ID로 결제 조회", description = "주문 ID로 결제 정보를 조회합니다.")
     @GetMapping("/orders/{orderId}")
     public ApiResponse<PaymentResponse> getPaymentByOrderId(
-            @CurrentUser User user,
+            @CurrentUser JwtUserPrincipal principal,
             @PathVariable String orderId) {
-        Payment payment = paymentQueryService.getPaymentByOrderId(orderId, user.getId());
+        Payment payment = paymentQueryService.getPaymentByOrderId(orderId, principal.getId());
         return ApiResponse.onSuccess(PaymentResponse.from(payment));
     }
 
     @Operation(summary = "결제 환불", description = "결제를 환불합니다. 환불 정책이 적용됩니다. (24시간 전: 100%, 12시간 전: 50%, 당일: 0%)")
     @PostMapping("/{paymentId}/refund")
     public ApiResponse<PaymentResponse> refundPayment(
-            @CurrentUser User user,
+            @CurrentUser JwtUserPrincipal principal,
             @PathVariable Long paymentId,
             @Valid @RequestBody RefundRequest request) {
-        Payment payment = paymentService.refundPayment(user.getId(), paymentId, request.cancelReason());
+        Payment payment = paymentService.refundPayment(principal.getId(), paymentId, request.cancelReason());
         return ApiResponse.onSuccess(PaymentResponse.from(payment));
     }
 
     @Operation(summary = "예약 ID로 결제 조회", description = "예약 ID로 결제 정보를 조회합니다.")
     @GetMapping("/reservations/{reservationId}")
     public ApiResponse<PaymentResponse> getPaymentByReservationId(
-            @CurrentUser User user,
+            @CurrentUser JwtUserPrincipal principal,
             @PathVariable Long reservationId) {
-        Payment payment = paymentQueryService.getPaymentByReservationId(reservationId, user.getId());
+        Payment payment = paymentQueryService.getPaymentByReservationId(reservationId, principal.getId());
         return ApiResponse.onSuccess(PaymentResponse.from(payment));
     }
 }

--- a/src/main/java/PetMoa/PetMoa/domain/payment/controller/PaymentController.java
+++ b/src/main/java/PetMoa/PetMoa/domain/payment/controller/PaymentController.java
@@ -7,7 +7,9 @@ import PetMoa.PetMoa.domain.payment.dto.RefundRequest;
 import PetMoa.PetMoa.domain.payment.entity.Payment;
 import PetMoa.PetMoa.domain.payment.service.PaymentQueryService;
 import PetMoa.PetMoa.domain.payment.service.PaymentService;
+import PetMoa.PetMoa.domain.user.entity.User;
 import PetMoa.PetMoa.global.apiPayload.ApiResponse;
+import PetMoa.PetMoa.global.security.CurrentUser;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -26,55 +28,55 @@ public class PaymentController {
     @Operation(summary = "결제 요청 생성", description = "예약에 대한 결제 요청을 생성하고 orderId를 발급합니다.")
     @PostMapping
     public ApiResponse<PaymentResponse> createPayment(
-            @RequestHeader("X-User-Id") Long userId,
+            @CurrentUser User user,
             @Valid @RequestBody PaymentCreateRequest request) {
-        Payment payment = paymentService.createPayment(userId, request);
+        Payment payment = paymentService.createPayment(user.getId(), request);
         return ApiResponse.onSuccess(PaymentResponse.from(payment));
     }
 
     @Operation(summary = "결제 승인", description = "토스페이먼츠 결제 승인을 처리합니다. 클라이언트에서 결제 완료 후 호출합니다.")
     @PostMapping("/confirm")
     public ApiResponse<PaymentResponse> confirmPayment(
-            @RequestHeader("X-User-Id") Long userId,
+            @CurrentUser User user,
             @Valid @RequestBody PaymentConfirmRequest request) {
-        Payment payment = paymentService.confirmPayment(userId, request);
+        Payment payment = paymentService.confirmPayment(user.getId(), request);
         return ApiResponse.onSuccess(PaymentResponse.from(payment));
     }
 
     @Operation(summary = "결제 조회", description = "결제 상세 정보를 조회합니다.")
     @GetMapping("/{paymentId}")
     public ApiResponse<PaymentResponse> getPayment(
-            @RequestHeader("X-User-Id") Long userId,
+            @CurrentUser User user,
             @PathVariable Long paymentId) {
-        Payment payment = paymentQueryService.getPaymentById(paymentId, userId);
+        Payment payment = paymentQueryService.getPaymentById(paymentId, user.getId());
         return ApiResponse.onSuccess(PaymentResponse.from(payment));
     }
 
     @Operation(summary = "주문 ID로 결제 조회", description = "주문 ID로 결제 정보를 조회합니다.")
     @GetMapping("/orders/{orderId}")
     public ApiResponse<PaymentResponse> getPaymentByOrderId(
-            @RequestHeader("X-User-Id") Long userId,
+            @CurrentUser User user,
             @PathVariable String orderId) {
-        Payment payment = paymentQueryService.getPaymentByOrderId(orderId, userId);
+        Payment payment = paymentQueryService.getPaymentByOrderId(orderId, user.getId());
         return ApiResponse.onSuccess(PaymentResponse.from(payment));
     }
 
     @Operation(summary = "결제 환불", description = "결제를 환불합니다. 환불 정책이 적용됩니다. (24시간 전: 100%, 12시간 전: 50%, 당일: 0%)")
     @PostMapping("/{paymentId}/refund")
     public ApiResponse<PaymentResponse> refundPayment(
-            @RequestHeader("X-User-Id") Long userId,
+            @CurrentUser User user,
             @PathVariable Long paymentId,
             @Valid @RequestBody RefundRequest request) {
-        Payment payment = paymentService.refundPayment(userId, paymentId, request.cancelReason());
+        Payment payment = paymentService.refundPayment(user.getId(), paymentId, request.cancelReason());
         return ApiResponse.onSuccess(PaymentResponse.from(payment));
     }
 
     @Operation(summary = "예약 ID로 결제 조회", description = "예약 ID로 결제 정보를 조회합니다.")
     @GetMapping("/reservations/{reservationId}")
     public ApiResponse<PaymentResponse> getPaymentByReservationId(
-            @RequestHeader("X-User-Id") Long userId,
+            @CurrentUser User user,
             @PathVariable Long reservationId) {
-        Payment payment = paymentQueryService.getPaymentByReservationId(reservationId, userId);
+        Payment payment = paymentQueryService.getPaymentByReservationId(reservationId, user.getId());
         return ApiResponse.onSuccess(PaymentResponse.from(payment));
     }
 }

--- a/src/main/java/PetMoa/PetMoa/domain/pet/controller/PetController.java
+++ b/src/main/java/PetMoa/PetMoa/domain/pet/controller/PetController.java
@@ -7,9 +7,9 @@ import PetMoa.PetMoa.domain.pet.dto.PetUpdateRequest;
 import PetMoa.PetMoa.domain.pet.entity.Pet;
 import PetMoa.PetMoa.domain.pet.service.PetCommandService;
 import PetMoa.PetMoa.domain.pet.service.PetQueryService;
-import PetMoa.PetMoa.domain.user.entity.User;
 import PetMoa.PetMoa.global.apiPayload.ApiResponse;
 import PetMoa.PetMoa.global.security.CurrentUser;
+import PetMoa.PetMoa.global.security.jwt.JwtUserPrincipal;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -28,36 +28,36 @@ public class PetController {
 
     @Operation(summary = "내 반려동물 목록 조회", description = "현재 로그인한 사용자의 반려동물 목록을 조회합니다.")
     @GetMapping
-    public ApiResponse<PetListResponse> getMyPets(@CurrentUser User user) {
-        List<Pet> pets = petQueryService.getPetsByOwnerId(user.getId());
+    public ApiResponse<PetListResponse> getMyPets(@CurrentUser JwtUserPrincipal principal) {
+        List<Pet> pets = petQueryService.getPetsByOwnerId(principal.getId());
         return ApiResponse.onSuccess(PetListResponse.from(pets));
     }
 
     @Operation(summary = "반려동물 등록", description = "새로운 반려동물을 등록합니다.")
     @PostMapping
     public ApiResponse<PetResponse> createPet(
-            @CurrentUser User user,
+            @CurrentUser JwtUserPrincipal principal,
             @RequestBody PetCreateRequest request) {
-        Pet pet = petCommandService.createPet(user.getId(), request);
+        Pet pet = petCommandService.createPet(principal.getId(), request);
         return ApiResponse.onSuccess(PetResponse.from(pet));
     }
 
     @Operation(summary = "반려동물 정보 수정", description = "반려동물 정보를 수정합니다.")
     @PatchMapping("/{petId}")
     public ApiResponse<PetResponse> updatePet(
-            @CurrentUser User user,
+            @CurrentUser JwtUserPrincipal principal,
             @PathVariable Long petId,
             @RequestBody PetUpdateRequest request) {
-        Pet pet = petCommandService.updatePet(user.getId(), petId, request);
+        Pet pet = petCommandService.updatePet(principal.getId(), petId, request);
         return ApiResponse.onSuccess(PetResponse.from(pet));
     }
 
     @Operation(summary = "반려동물 삭제", description = "반려동물을 삭제합니다.")
     @DeleteMapping("/{petId}")
     public ApiResponse<Void> deletePet(
-            @CurrentUser User user,
+            @CurrentUser JwtUserPrincipal principal,
             @PathVariable Long petId) {
-        petCommandService.deletePet(user.getId(), petId);
+        petCommandService.deletePet(principal.getId(), petId);
         return ApiResponse.onSuccess(null);
     }
 }

--- a/src/main/java/PetMoa/PetMoa/domain/pet/controller/PetController.java
+++ b/src/main/java/PetMoa/PetMoa/domain/pet/controller/PetController.java
@@ -7,7 +7,9 @@ import PetMoa.PetMoa.domain.pet.dto.PetUpdateRequest;
 import PetMoa.PetMoa.domain.pet.entity.Pet;
 import PetMoa.PetMoa.domain.pet.service.PetCommandService;
 import PetMoa.PetMoa.domain.pet.service.PetQueryService;
+import PetMoa.PetMoa.domain.user.entity.User;
 import PetMoa.PetMoa.global.apiPayload.ApiResponse;
+import PetMoa.PetMoa.global.security.CurrentUser;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -26,37 +28,36 @@ public class PetController {
 
     @Operation(summary = "내 반려동물 목록 조회", description = "현재 로그인한 사용자의 반려동물 목록을 조회합니다.")
     @GetMapping
-    public ApiResponse<PetListResponse> getMyPets(
-            @RequestHeader("X-User-Id") Long userId) {
-        List<Pet> pets = petQueryService.getPetsByOwnerId(userId);
+    public ApiResponse<PetListResponse> getMyPets(@CurrentUser User user) {
+        List<Pet> pets = petQueryService.getPetsByOwnerId(user.getId());
         return ApiResponse.onSuccess(PetListResponse.from(pets));
     }
 
     @Operation(summary = "반려동물 등록", description = "새로운 반려동물을 등록합니다.")
     @PostMapping
     public ApiResponse<PetResponse> createPet(
-            @RequestHeader("X-User-Id") Long userId,
+            @CurrentUser User user,
             @RequestBody PetCreateRequest request) {
-        Pet pet = petCommandService.createPet(userId, request);
+        Pet pet = petCommandService.createPet(user.getId(), request);
         return ApiResponse.onSuccess(PetResponse.from(pet));
     }
 
     @Operation(summary = "반려동물 정보 수정", description = "반려동물 정보를 수정합니다.")
     @PatchMapping("/{petId}")
     public ApiResponse<PetResponse> updatePet(
-            @RequestHeader("X-User-Id") Long userId,
+            @CurrentUser User user,
             @PathVariable Long petId,
             @RequestBody PetUpdateRequest request) {
-        Pet pet = petCommandService.updatePet(userId, petId, request);
+        Pet pet = petCommandService.updatePet(user.getId(), petId, request);
         return ApiResponse.onSuccess(PetResponse.from(pet));
     }
 
     @Operation(summary = "반려동물 삭제", description = "반려동물을 삭제합니다.")
     @DeleteMapping("/{petId}")
     public ApiResponse<Void> deletePet(
-            @RequestHeader("X-User-Id") Long userId,
+            @CurrentUser User user,
             @PathVariable Long petId) {
-        petCommandService.deletePet(userId, petId);
+        petCommandService.deletePet(user.getId(), petId);
         return ApiResponse.onSuccess(null);
     }
 }

--- a/src/main/java/PetMoa/PetMoa/domain/reservation/controller/ReservationController.java
+++ b/src/main/java/PetMoa/PetMoa/domain/reservation/controller/ReservationController.java
@@ -8,7 +8,9 @@ import PetMoa.PetMoa.domain.reservation.dto.ReservationResponse;
 import PetMoa.PetMoa.domain.reservation.entity.Reservation;
 import PetMoa.PetMoa.domain.reservation.service.ReservationFacade;
 import PetMoa.PetMoa.domain.reservation.service.ReservationQueryService;
+import PetMoa.PetMoa.domain.user.entity.User;
 import PetMoa.PetMoa.global.apiPayload.ApiResponse;
+import PetMoa.PetMoa.global.security.CurrentUser;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -28,35 +30,34 @@ public class ReservationController {
     @Operation(summary = "통합 예약 생성", description = "병원 예약 + 택시 예약(선택)을 생성합니다.")
     @PostMapping
     public ApiResponse<ReservationResponse> createReservation(
-            @RequestHeader("X-User-Id") Long userId,
+            @CurrentUser User user,
             @RequestBody ReservationCreateRequest request) {
-        Reservation reservation = reservationFacade.createReservation(userId, request);
+        Reservation reservation = reservationFacade.createReservation(user.getId(), request);
         return ApiResponse.onSuccess(ReservationResponse.from(reservation));
     }
 
     @Operation(summary = "내 예약 목록 조회", description = "현재 로그인한 사용자의 예약 목록을 조회합니다.")
     @GetMapping
-    public ApiResponse<ReservationListResponse> getMyReservations(
-            @RequestHeader("X-User-Id") Long userId) {
-        List<Reservation> reservations = reservationQueryService.getReservationsByUserId(userId);
+    public ApiResponse<ReservationListResponse> getMyReservations(@CurrentUser User user) {
+        List<Reservation> reservations = reservationQueryService.getReservationsByUserId(user.getId());
         return ApiResponse.onSuccess(ReservationListResponse.from(reservations));
     }
 
     @Operation(summary = "예약 상세 조회", description = "예약 상세 정보를 조회합니다.")
     @GetMapping("/{reservationId}")
     public ApiResponse<ReservationResponse> getReservation(
-            @RequestHeader("X-User-Id") Long userId,
+            @CurrentUser User user,
             @PathVariable Long reservationId) {
-        Reservation reservation = reservationQueryService.getReservationByIdAndUserId(reservationId, userId);
+        Reservation reservation = reservationQueryService.getReservationByIdAndUserId(reservationId, user.getId());
         return ApiResponse.onSuccess(ReservationResponse.from(reservation));
     }
 
     @Operation(summary = "예약 취소", description = "예약을 취소합니다. 결제가 존재하면 환불 정책에 따라 자동 환불됩니다.")
     @PostMapping("/{reservationId}/cancel")
     public ApiResponse<ReservationCancelResponse> cancelReservation(
-            @RequestHeader("X-User-Id") Long userId,
+            @CurrentUser User user,
             @PathVariable Long reservationId) {
-        CancellationResult result = reservationFacade.cancelReservation(userId, reservationId);
+        CancellationResult result = reservationFacade.cancelReservation(user.getId(), reservationId);
         return ApiResponse.onSuccess(ReservationCancelResponse.from(
                 result.reservation(),
                 result.refundRate(),

--- a/src/main/java/PetMoa/PetMoa/domain/reservation/controller/ReservationController.java
+++ b/src/main/java/PetMoa/PetMoa/domain/reservation/controller/ReservationController.java
@@ -8,9 +8,9 @@ import PetMoa.PetMoa.domain.reservation.dto.ReservationResponse;
 import PetMoa.PetMoa.domain.reservation.entity.Reservation;
 import PetMoa.PetMoa.domain.reservation.service.ReservationFacade;
 import PetMoa.PetMoa.domain.reservation.service.ReservationQueryService;
-import PetMoa.PetMoa.domain.user.entity.User;
 import PetMoa.PetMoa.global.apiPayload.ApiResponse;
 import PetMoa.PetMoa.global.security.CurrentUser;
+import PetMoa.PetMoa.global.security.jwt.JwtUserPrincipal;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -30,34 +30,34 @@ public class ReservationController {
     @Operation(summary = "통합 예약 생성", description = "병원 예약 + 택시 예약(선택)을 생성합니다.")
     @PostMapping
     public ApiResponse<ReservationResponse> createReservation(
-            @CurrentUser User user,
+            @CurrentUser JwtUserPrincipal principal,
             @RequestBody ReservationCreateRequest request) {
-        Reservation reservation = reservationFacade.createReservation(user.getId(), request);
+        Reservation reservation = reservationFacade.createReservation(principal.getId(), request);
         return ApiResponse.onSuccess(ReservationResponse.from(reservation));
     }
 
     @Operation(summary = "내 예약 목록 조회", description = "현재 로그인한 사용자의 예약 목록을 조회합니다.")
     @GetMapping
-    public ApiResponse<ReservationListResponse> getMyReservations(@CurrentUser User user) {
-        List<Reservation> reservations = reservationQueryService.getReservationsByUserId(user.getId());
+    public ApiResponse<ReservationListResponse> getMyReservations(@CurrentUser JwtUserPrincipal principal) {
+        List<Reservation> reservations = reservationQueryService.getReservationsByUserId(principal.getId());
         return ApiResponse.onSuccess(ReservationListResponse.from(reservations));
     }
 
     @Operation(summary = "예약 상세 조회", description = "예약 상세 정보를 조회합니다.")
     @GetMapping("/{reservationId}")
     public ApiResponse<ReservationResponse> getReservation(
-            @CurrentUser User user,
+            @CurrentUser JwtUserPrincipal principal,
             @PathVariable Long reservationId) {
-        Reservation reservation = reservationQueryService.getReservationByIdAndUserId(reservationId, user.getId());
+        Reservation reservation = reservationQueryService.getReservationByIdAndUserId(reservationId, principal.getId());
         return ApiResponse.onSuccess(ReservationResponse.from(reservation));
     }
 
     @Operation(summary = "예약 취소", description = "예약을 취소합니다. 결제가 존재하면 환불 정책에 따라 자동 환불됩니다.")
     @PostMapping("/{reservationId}/cancel")
     public ApiResponse<ReservationCancelResponse> cancelReservation(
-            @CurrentUser User user,
+            @CurrentUser JwtUserPrincipal principal,
             @PathVariable Long reservationId) {
-        CancellationResult result = reservationFacade.cancelReservation(user.getId(), reservationId);
+        CancellationResult result = reservationFacade.cancelReservation(principal.getId(), reservationId);
         return ApiResponse.onSuccess(ReservationCancelResponse.from(
                 result.reservation(),
                 result.refundRate(),

--- a/src/main/java/PetMoa/PetMoa/domain/user/controller/UserController.java
+++ b/src/main/java/PetMoa/PetMoa/domain/user/controller/UserController.java
@@ -4,8 +4,8 @@ import PetMoa.PetMoa.domain.user.dto.UserResponse;
 import PetMoa.PetMoa.domain.user.dto.UserUpdateRequest;
 import PetMoa.PetMoa.domain.user.entity.User;
 import PetMoa.PetMoa.domain.user.service.UserCommandService;
-import PetMoa.PetMoa.domain.user.service.UserQueryService;
 import PetMoa.PetMoa.global.apiPayload.ApiResponse;
+import PetMoa.PetMoa.global.security.CurrentUser;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -17,23 +17,20 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class UserController {
 
-    private final UserQueryService userQueryService;
     private final UserCommandService userCommandService;
 
     @Operation(summary = "내 정보 조회", description = "현재 로그인한 사용자의 정보를 조회합니다.")
     @GetMapping("/me")
-    public ApiResponse<UserResponse> getMyInfo(
-            @RequestHeader("X-User-Id") Long userId) {
-        User user = userQueryService.getUserById(userId);
+    public ApiResponse<UserResponse> getMyInfo(@CurrentUser User user) {
         return ApiResponse.onSuccess(UserResponse.from(user));
     }
 
     @Operation(summary = "내 정보 수정", description = "현재 로그인한 사용자의 정보를 수정합니다.")
     @PatchMapping("/me")
     public ApiResponse<UserResponse> updateMyInfo(
-            @RequestHeader("X-User-Id") Long userId,
+            @CurrentUser User user,
             @RequestBody UserUpdateRequest request) {
-        User user = userCommandService.updateUser(userId, request);
-        return ApiResponse.onSuccess(UserResponse.from(user));
+        User updatedUser = userCommandService.updateUser(user.getId(), request);
+        return ApiResponse.onSuccess(UserResponse.from(updatedUser));
     }
 }

--- a/src/main/java/PetMoa/PetMoa/domain/user/controller/UserController.java
+++ b/src/main/java/PetMoa/PetMoa/domain/user/controller/UserController.java
@@ -4,8 +4,10 @@ import PetMoa.PetMoa.domain.user.dto.UserResponse;
 import PetMoa.PetMoa.domain.user.dto.UserUpdateRequest;
 import PetMoa.PetMoa.domain.user.entity.User;
 import PetMoa.PetMoa.domain.user.service.UserCommandService;
+import PetMoa.PetMoa.domain.user.service.UserQueryService;
 import PetMoa.PetMoa.global.apiPayload.ApiResponse;
 import PetMoa.PetMoa.global.security.CurrentUser;
+import PetMoa.PetMoa.global.security.jwt.JwtUserPrincipal;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -18,19 +20,21 @@ import org.springframework.web.bind.annotation.*;
 public class UserController {
 
     private final UserCommandService userCommandService;
+    private final UserQueryService userQueryService;
 
     @Operation(summary = "내 정보 조회", description = "현재 로그인한 사용자의 정보를 조회합니다.")
     @GetMapping("/me")
-    public ApiResponse<UserResponse> getMyInfo(@CurrentUser User user) {
+    public ApiResponse<UserResponse> getMyInfo(@CurrentUser JwtUserPrincipal principal) {
+        User user = userQueryService.getUserById(principal.getId());
         return ApiResponse.onSuccess(UserResponse.from(user));
     }
 
     @Operation(summary = "내 정보 수정", description = "현재 로그인한 사용자의 정보를 수정합니다.")
     @PatchMapping("/me")
     public ApiResponse<UserResponse> updateMyInfo(
-            @CurrentUser User user,
+            @CurrentUser JwtUserPrincipal principal,
             @RequestBody UserUpdateRequest request) {
-        User updatedUser = userCommandService.updateUser(user.getId(), request);
+        User updatedUser = userCommandService.updateUser(principal.getId(), request);
         return ApiResponse.onSuccess(UserResponse.from(updatedUser));
     }
 }

--- a/src/main/java/PetMoa/PetMoa/domain/user/entity/AuthProvider.java
+++ b/src/main/java/PetMoa/PetMoa/domain/user/entity/AuthProvider.java
@@ -1,0 +1,9 @@
+package PetMoa.PetMoa.domain.user.entity;
+
+/**
+ * 소셜 로그인 제공자
+ */
+public enum AuthProvider {
+    KAKAO
+    // 추후 확장: GOOGLE, NAVER, APPLE
+}

--- a/src/main/java/PetMoa/PetMoa/domain/user/entity/Role.java
+++ b/src/main/java/PetMoa/PetMoa/domain/user/entity/Role.java
@@ -1,0 +1,9 @@
+package PetMoa.PetMoa.domain.user.entity;
+
+/**
+ * 사용자 역할
+ */
+public enum Role {
+    USER,
+    ADMIN
+}

--- a/src/main/java/PetMoa/PetMoa/domain/user/entity/User.java
+++ b/src/main/java/PetMoa/PetMoa/domain/user/entity/User.java
@@ -23,14 +23,25 @@ public class User {
     @Column(nullable = false, length = 50)
     private String name;
 
-    @Column(nullable = false, unique = true, length = 20)
+    @Column(unique = true, length = 20)
     private String phoneNumber;
 
-    @Column(nullable = false, length = 200)
+    @Column(length = 200)
     private String address;
 
     @Column(length = 100)
     private String email;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 20)
+    private AuthProvider provider;
+
+    @Column(unique = true)
+    private String providerId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private Role role = Role.USER;
 
     @OneToMany(mappedBy = "owner", cascade = CascadeType.ALL)
     private List<Pet> pets = new ArrayList<>();
@@ -50,31 +61,43 @@ public class User {
     private static final Pattern EMAIL_PATTERN = Pattern.compile("^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$");
 
     @Builder
-    public User(String name, String phoneNumber, String address, String email) {
-        validateFields(name, phoneNumber, address, email);
+    public User(String name, String phoneNumber, String address, String email,
+                AuthProvider provider, String providerId, Role role) {
+        validateFields(name, phoneNumber, address, email, provider);
 
         this.name = name;
         this.phoneNumber = phoneNumber;
         this.address = address;
         this.email = email;
+        this.provider = provider;
+        this.providerId = providerId;
+        this.role = (role != null) ? role : Role.USER;
         this.createdAt = LocalDateTime.now();
     }
 
-    private void validateFields(String name, String phoneNumber, String address, String email) {
+    private void validateFields(String name, String phoneNumber, String address, String email, AuthProvider provider) {
         if (name == null || name.isBlank()) {
             throw new IllegalArgumentException("이름은 필수입니다.");
         }
 
-        if (phoneNumber == null || phoneNumber.isBlank()) {
-            throw new IllegalArgumentException("전화번호는 필수입니다.");
-        }
+        // 소셜 로그인이 아닌 경우에만 전화번호, 주소 필수
+        if (provider == null) {
+            if (phoneNumber == null || phoneNumber.isBlank()) {
+                throw new IllegalArgumentException("전화번호는 필수입니다.");
+            }
 
-        if (!PHONE_PATTERN.matcher(phoneNumber).matches()) {
-            throw new IllegalArgumentException("전화번호 형식이 올바르지 않습니다. (예: 010-1234-5678 또는 01012345678)");
-        }
+            if (!PHONE_PATTERN.matcher(phoneNumber).matches()) {
+                throw new IllegalArgumentException("전화번호 형식이 올바르지 않습니다. (예: 010-1234-5678 또는 01012345678)");
+            }
 
-        if (address == null || address.isBlank()) {
-            throw new IllegalArgumentException("주소는 필수입니다.");
+            if (address == null || address.isBlank()) {
+                throw new IllegalArgumentException("주소는 필수입니다.");
+            }
+        } else {
+            // 소셜 로그인인 경우에도 전화번호가 있으면 형식 검증
+            if (phoneNumber != null && !phoneNumber.isBlank() && !PHONE_PATTERN.matcher(phoneNumber).matches()) {
+                throw new IllegalArgumentException("전화번호 형식이 올바르지 않습니다. (예: 010-1234-5678 또는 01012345678)");
+            }
         }
 
         if (email != null && !email.isBlank() && !EMAIL_PATTERN.matcher(email).matches()) {
@@ -97,6 +120,19 @@ public class User {
         }
         if (address != null && !address.isBlank()) {
             this.address = address;
+        }
+    }
+
+    // 소셜 로그인 사용자 프로필 업데이트
+    public void updateSocialProfile(String name, String email) {
+        if (name != null && !name.isBlank()) {
+            this.name = name;
+        }
+        if (email != null && !email.isBlank()) {
+            if (!EMAIL_PATTERN.matcher(email).matches()) {
+                throw new IllegalArgumentException("이메일 형식이 올바르지 않습니다.");
+            }
+            this.email = email;
         }
     }
 

--- a/src/main/java/PetMoa/PetMoa/domain/user/repository/UserRepository.java
+++ b/src/main/java/PetMoa/PetMoa/domain/user/repository/UserRepository.java
@@ -1,5 +1,6 @@
 package PetMoa.PetMoa.domain.user.repository;
 
+import PetMoa.PetMoa.domain.user.entity.AuthProvider;
 import PetMoa.PetMoa.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -10,4 +11,9 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByPhoneNumber(String phoneNumber);
 
     boolean existsByPhoneNumber(String phoneNumber);
+
+    // 소셜 로그인용
+    Optional<User> findByProviderAndProviderId(AuthProvider provider, String providerId);
+
+    Optional<User> findByEmail(String email);
 }

--- a/src/main/java/PetMoa/PetMoa/global/config/SecurityConfig.java
+++ b/src/main/java/PetMoa/PetMoa/global/config/SecurityConfig.java
@@ -1,0 +1,74 @@
+package PetMoa.PetMoa.global.config;
+
+import PetMoa.PetMoa.global.security.jwt.JwtAuthenticationEntryPoint;
+import PetMoa.PetMoa.global.security.jwt.JwtAuthenticationFilter;
+import PetMoa.PetMoa.global.security.oauth2.CustomOAuth2UserService;
+import PetMoa.PetMoa.global.security.oauth2.OAuth2AuthenticationFailureHandler;
+import PetMoa.PetMoa.global.security.oauth2.OAuth2AuthenticationSuccessHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    private final CustomOAuth2UserService customOAuth2UserService;
+    private final OAuth2AuthenticationSuccessHandler oAuth2SuccessHandler;
+    private final OAuth2AuthenticationFailureHandler oAuth2FailureHandler;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                // CSRF 비활성화 (JWT 사용)
+                .csrf(csrf -> csrf.disable())
+
+                // 세션 사용 안함 (Stateless)
+                .sessionManagement(session ->
+                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+
+                // 인증 실패 처리
+                .exceptionHandling(exception ->
+                        exception.authenticationEntryPoint(jwtAuthenticationEntryPoint))
+
+                // 요청 권한 설정
+                .authorizeHttpRequests(auth -> auth
+                        // 공개 엔드포인트
+                        .requestMatchers(
+                                "/",
+                                "/swagger-ui/**",
+                                "/v3/api-docs/**",
+                                "/api/v1/auth/**",
+                                "/oauth2/**",
+                                "/login/**",
+                                "/api/v1/hospitals/**",
+                                "/api/v1/pet-taxis/check-availability"
+                        ).permitAll()
+
+                        // 나머지는 인증 필요
+                        .anyRequest().authenticated()
+                )
+
+                // OAuth2 로그인 설정
+                .oauth2Login(oauth2 -> oauth2
+                        .userInfoEndpoint(userInfo ->
+                                userInfo.userService(customOAuth2UserService))
+                        .successHandler(oAuth2SuccessHandler)
+                        .failureHandler(oAuth2FailureHandler)
+                )
+
+                // JWT 필터 추가
+                .addFilterBefore(jwtAuthenticationFilter,
+                        UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+}

--- a/src/main/java/PetMoa/PetMoa/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/PetMoa/PetMoa/global/exception/GlobalExceptionHandler.java
@@ -78,6 +78,21 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
     }
 
+    @ExceptionHandler(UnauthorizedException.class)
+    public ResponseEntity<ErrorResponse> handleUnauthorizedException(
+            UnauthorizedException e, HttpServletRequest request) {
+        log.warn("UnauthorizedException: {}", e.getMessage());
+
+        ErrorResponse response = ErrorResponse.of(
+                HttpStatus.UNAUTHORIZED.value(),
+                "Unauthorized",
+                e.getMessage(),
+                request.getRequestURI()
+        );
+
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(response);
+    }
+
     @ExceptionHandler(ForbiddenException.class)
     public ResponseEntity<ErrorResponse> handleForbiddenException(
             ForbiddenException e, HttpServletRequest request) {

--- a/src/main/java/PetMoa/PetMoa/global/exception/UnauthorizedException.java
+++ b/src/main/java/PetMoa/PetMoa/global/exception/UnauthorizedException.java
@@ -1,0 +1,15 @@
+package PetMoa.PetMoa.global.exception;
+
+/**
+ * 인증 실패 예외 (401)
+ */
+public class UnauthorizedException extends RuntimeException {
+
+    public UnauthorizedException(String message) {
+        super(message);
+    }
+
+    public UnauthorizedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/PetMoa/PetMoa/global/security/CurrentUser.java
+++ b/src/main/java/PetMoa/PetMoa/global/security/CurrentUser.java
@@ -1,0 +1,16 @@
+package PetMoa.PetMoa.global.security;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+import java.lang.annotation.*;
+
+/**
+ * 현재 인증된 사용자를 주입받기 위한 어노테이션
+ * Controller 파라미터에 사용: @CurrentUser User user
+ */
+@Target({ElementType.PARAMETER, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@AuthenticationPrincipal
+public @interface CurrentUser {
+}

--- a/src/main/java/PetMoa/PetMoa/global/security/jwt/CookieUtils.java
+++ b/src/main/java/PetMoa/PetMoa/global/security/jwt/CookieUtils.java
@@ -1,0 +1,99 @@
+package PetMoa.PetMoa.global.security.jwt;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class CookieUtils {
+
+    private final JwtProperties jwtProperties;
+
+    public static final String ACCESS_TOKEN_COOKIE = "access_token";
+    public static final String REFRESH_TOKEN_COOKIE = "refresh_token";
+
+    /**
+     * Access Token 쿠키 추가
+     */
+    public void addAccessTokenCookie(HttpServletResponse response, String accessToken) {
+        int maxAge = (int) (jwtProperties.getAccessTokenExpiry() / 1000);
+        addCookie(response, ACCESS_TOKEN_COOKIE, accessToken, maxAge);
+    }
+
+    /**
+     * Refresh Token 쿠키 추가
+     */
+    public void addRefreshTokenCookie(HttpServletResponse response, String refreshToken) {
+        int maxAge = (int) (jwtProperties.getRefreshTokenExpiry() / 1000);
+        addCookie(response, REFRESH_TOKEN_COOKIE, refreshToken, maxAge);
+    }
+
+    /**
+     * 쿠키 추가 (HttpOnly, Secure, SameSite=Strict)
+     */
+    private void addCookie(HttpServletResponse response, String name, String value, int maxAge) {
+        Cookie cookie = new Cookie(name, value);
+        cookie.setHttpOnly(true);
+        cookie.setSecure(false); // 개발환경: false, 운영환경: true
+        cookie.setPath("/");
+        cookie.setMaxAge(maxAge);
+        // SameSite는 Cookie 객체에서 직접 지원하지 않으므로 헤더로 설정
+        response.addHeader("Set-Cookie",
+                String.format("%s=%s; Max-Age=%d; Path=/; HttpOnly; SameSite=Strict",
+                        name, value, maxAge));
+    }
+
+    /**
+     * 쿠키에서 값 읽기
+     */
+    public Optional<String> getCookieValue(HttpServletRequest request, String name) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) {
+            return Optional.empty();
+        }
+        return Arrays.stream(cookies)
+                .filter(cookie -> name.equals(cookie.getName()))
+                .map(Cookie::getValue)
+                .findFirst();
+    }
+
+    /**
+     * Access Token 쿠키 삭제
+     */
+    public void deleteAccessTokenCookie(HttpServletResponse response) {
+        deleteCookie(response, ACCESS_TOKEN_COOKIE);
+    }
+
+    /**
+     * Refresh Token 쿠키 삭제
+     */
+    public void deleteRefreshTokenCookie(HttpServletResponse response) {
+        deleteCookie(response, REFRESH_TOKEN_COOKIE);
+    }
+
+    /**
+     * 모든 인증 쿠키 삭제
+     */
+    public void deleteAllAuthCookies(HttpServletResponse response) {
+        deleteAccessTokenCookie(response);
+        deleteRefreshTokenCookie(response);
+    }
+
+    /**
+     * 쿠키 삭제
+     */
+    private void deleteCookie(HttpServletResponse response, String name) {
+        Cookie cookie = new Cookie(name, "");
+        cookie.setHttpOnly(true);
+        cookie.setSecure(false);
+        cookie.setPath("/");
+        cookie.setMaxAge(0);
+        response.addCookie(cookie);
+    }
+}

--- a/src/main/java/PetMoa/PetMoa/global/security/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/PetMoa/PetMoa/global/security/jwt/JwtAuthenticationEntryPoint.java
@@ -1,9 +1,9 @@
 package PetMoa.PetMoa.global.security.jwt;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.AuthenticationException;
@@ -20,14 +20,10 @@ import java.util.Map;
  */
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
     private final ObjectMapper objectMapper;
-
-    public JwtAuthenticationEntryPoint() {
-        this.objectMapper = new ObjectMapper();
-        this.objectMapper.registerModule(new JavaTimeModule());
-    }
 
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response,

--- a/src/main/java/PetMoa/PetMoa/global/security/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/PetMoa/PetMoa/global/security/jwt/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,50 @@
+package PetMoa.PetMoa.global.security.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * 인증되지 않은 요청에 대한 401 응답 처리
+ */
+@Slf4j
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    public JwtAuthenticationEntryPoint() {
+        this.objectMapper = new ObjectMapper();
+        this.objectMapper.registerModule(new JavaTimeModule());
+    }
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+        log.warn("Unauthorized request to: {} - {}", request.getRequestURI(), authException.getMessage());
+
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+
+        Map<String, Object> body = new HashMap<>();
+        body.put("timestamp", LocalDateTime.now().toString());
+        body.put("status", 401);
+        body.put("error", "Unauthorized");
+        body.put("message", "인증이 필요합니다.");
+        body.put("path", request.getRequestURI());
+
+        objectMapper.writeValue(response.getOutputStream(), body);
+    }
+}

--- a/src/main/java/PetMoa/PetMoa/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/PetMoa/PetMoa/global/security/jwt/JwtAuthenticationFilter.java
@@ -1,7 +1,7 @@
 package PetMoa.PetMoa.global.security.jwt;
 
-import PetMoa.PetMoa.domain.user.entity.User;
-import PetMoa.PetMoa.domain.user.repository.UserRepository;
+import PetMoa.PetMoa.domain.user.entity.Role;
+import io.jsonwebtoken.Claims;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -20,7 +20,7 @@ import java.util.Collections;
 
 /**
  * JWT 토큰을 파싱하여 SecurityContext에 인증 정보를 설정하는 필터
- * 쿠키 또는 Authorization 헤더에서 토큰을 읽음
+ * DB 조회 없이 토큰 정보만으로 인증 처리
  */
 @Slf4j
 @Component
@@ -28,7 +28,6 @@ import java.util.Collections;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwtTokenProvider;
-    private final UserRepository userRepository;
     private final CookieUtils cookieUtils;
 
     private static final String AUTHORIZATION_HEADER = "Authorization";
@@ -41,21 +40,24 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         if (StringUtils.hasText(token) && jwtTokenProvider.validateToken(token)) {
             try {
-                Long userId = jwtTokenProvider.getUserIdFromToken(token);
-                User user = userRepository.findById(userId).orElse(null);
+                // 토큰에서 사용자 정보 추출 (DB 조회 없음)
+                Claims claims = jwtTokenProvider.getClaimsFromToken(token);
+                Long userId = Long.parseLong(claims.getSubject());
+                String email = claims.get("email", String.class);
+                Role role = Role.valueOf(claims.get("role", String.class));
 
-                if (user != null) {
-                    UsernamePasswordAuthenticationToken authentication =
-                            new UsernamePasswordAuthenticationToken(
-                                    user,
-                                    null,
-                                    Collections.singletonList(
-                                            new SimpleGrantedAuthority("ROLE_" + user.getRole().name()))
-                            );
+                JwtUserPrincipal principal = JwtUserPrincipal.of(userId, email, role);
 
-                    SecurityContextHolder.getContext().setAuthentication(authentication);
-                    log.debug("JWT authentication success - userId: {}", userId);
-                }
+                UsernamePasswordAuthenticationToken authentication =
+                        new UsernamePasswordAuthenticationToken(
+                                principal,
+                                null,
+                                Collections.singletonList(
+                                        new SimpleGrantedAuthority("ROLE_" + role.name()))
+                        );
+
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+                log.debug("JWT authentication success - userId: {}", userId);
             } catch (Exception e) {
                 log.warn("JWT authentication failed: {}", e.getMessage());
             }

--- a/src/main/java/PetMoa/PetMoa/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/PetMoa/PetMoa/global/security/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,72 @@
+package PetMoa.PetMoa.global.security.jwt;
+
+import PetMoa.PetMoa.domain.user.entity.User;
+import PetMoa.PetMoa.domain.user.repository.UserRepository;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Collections;
+
+/**
+ * JWT 토큰을 파싱하여 SecurityContext에 인증 정보를 설정하는 필터
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final UserRepository userRepository;
+
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String token = resolveToken(request);
+
+        if (StringUtils.hasText(token) && jwtTokenProvider.validateToken(token)) {
+            try {
+                Long userId = jwtTokenProvider.getUserIdFromToken(token);
+                User user = userRepository.findById(userId).orElse(null);
+
+                if (user != null) {
+                    UsernamePasswordAuthenticationToken authentication =
+                            new UsernamePasswordAuthenticationToken(
+                                    user,
+                                    null,
+                                    Collections.singletonList(
+                                            new SimpleGrantedAuthority("ROLE_" + user.getRole().name()))
+                            );
+
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                    log.debug("JWT authentication success - userId: {}", userId);
+                }
+            } catch (Exception e) {
+                log.warn("JWT authentication failed: {}", e.getMessage());
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+            return bearerToken.substring(BEARER_PREFIX.length());
+        }
+        return null;
+    }
+}

--- a/src/main/java/PetMoa/PetMoa/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/PetMoa/PetMoa/global/security/jwt/JwtAuthenticationFilter.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 
 /**
  * JWT 토큰을 파싱하여 SecurityContext에 인증 정보를 설정하는 필터
+ * 쿠키 또는 Authorization 헤더에서 토큰을 읽음
  */
 @Slf4j
 @Component
@@ -28,6 +29,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final UserRepository userRepository;
+    private final CookieUtils cookieUtils;
 
     private static final String AUTHORIZATION_HEADER = "Authorization";
     private static final String BEARER_PREFIX = "Bearer ";
@@ -62,11 +64,23 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         filterChain.doFilter(request, response);
     }
 
+    /**
+     * 쿠키 우선, 없으면 Authorization 헤더에서 토큰 추출
+     */
     private String resolveToken(HttpServletRequest request) {
+        // 1. 쿠키에서 Access Token 확인
+        String cookieToken = cookieUtils.getCookieValue(request, CookieUtils.ACCESS_TOKEN_COOKIE)
+                .orElse(null);
+        if (StringUtils.hasText(cookieToken)) {
+            return cookieToken;
+        }
+
+        // 2. Authorization 헤더에서 Bearer 토큰 확인 (하위 호환성)
         String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
         if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
             return bearerToken.substring(BEARER_PREFIX.length());
         }
+
         return null;
     }
 }

--- a/src/main/java/PetMoa/PetMoa/global/security/jwt/JwtProperties.java
+++ b/src/main/java/PetMoa/PetMoa/global/security/jwt/JwtProperties.java
@@ -1,0 +1,16 @@
+package PetMoa.PetMoa.global.security.jwt;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "jwt")
+public class JwtProperties {
+    private String secret;
+    private long accessTokenExpiry;   // 30분 (밀리초)
+    private long refreshTokenExpiry;  // 7일 (밀리초)
+}

--- a/src/main/java/PetMoa/PetMoa/global/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/PetMoa/PetMoa/global/security/jwt/JwtTokenProvider.java
@@ -1,0 +1,97 @@
+package PetMoa.PetMoa.global.security.jwt;
+
+import PetMoa.PetMoa.domain.user.entity.User;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+
+    private final JwtProperties jwtProperties;
+    private SecretKey secretKey;
+
+    @PostConstruct
+    protected void init() {
+        this.secretKey = Keys.hmacShaKeyFor(
+                jwtProperties.getSecret().getBytes(StandardCharsets.UTF_8));
+    }
+
+    // Access Token 생성
+    public String createAccessToken(User user) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + jwtProperties.getAccessTokenExpiry());
+
+        return Jwts.builder()
+                .subject(String.valueOf(user.getId()))
+                .claim("role", user.getRole().name())
+                .claim("email", user.getEmail())
+                .issuedAt(now)
+                .expiration(expiry)
+                .signWith(secretKey)
+                .compact();
+    }
+
+    // Refresh Token 생성
+    public String createRefreshToken(User user) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + jwtProperties.getRefreshTokenExpiry());
+
+        return Jwts.builder()
+                .subject(String.valueOf(user.getId()))
+                .issuedAt(now)
+                .expiration(expiry)
+                .signWith(secretKey)
+                .compact();
+    }
+
+    // 토큰에서 사용자 ID 추출
+    public Long getUserIdFromToken(String token) {
+        Claims claims = parseClaims(token);
+        return Long.parseLong(claims.getSubject());
+    }
+
+    // 토큰 유효성 검증
+    public boolean validateToken(String token) {
+        try {
+            parseClaims(token);
+            return true;
+        } catch (ExpiredJwtException e) {
+            log.warn("만료된 JWT 토큰입니다.");
+        } catch (UnsupportedJwtException e) {
+            log.warn("지원되지 않는 JWT 토큰입니다.");
+        } catch (MalformedJwtException e) {
+            log.warn("잘못된 JWT 토큰입니다.");
+        } catch (SecurityException e) {
+            log.warn("잘못된 JWT 서명입니다.");
+        } catch (IllegalArgumentException e) {
+            log.warn("JWT 토큰이 비어있습니다.");
+        }
+        return false;
+    }
+
+    private Claims parseClaims(String token) {
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+
+    public long getAccessTokenExpiry() {
+        return jwtProperties.getAccessTokenExpiry();
+    }
+
+    public long getRefreshTokenExpiry() {
+        return jwtProperties.getRefreshTokenExpiry();
+    }
+}

--- a/src/main/java/PetMoa/PetMoa/global/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/PetMoa/PetMoa/global/security/jwt/JwtTokenProvider.java
@@ -60,6 +60,11 @@ public class JwtTokenProvider {
         return Long.parseLong(claims.getSubject());
     }
 
+    // 토큰에서 Claims 추출 (외부에서 사용)
+    public Claims getClaimsFromToken(String token) {
+        return parseClaims(token);
+    }
+
     // 토큰 유효성 검증
     public boolean validateToken(String token) {
         try {

--- a/src/main/java/PetMoa/PetMoa/global/security/jwt/JwtUserPrincipal.java
+++ b/src/main/java/PetMoa/PetMoa/global/security/jwt/JwtUserPrincipal.java
@@ -1,0 +1,22 @@
+package PetMoa.PetMoa.global.security.jwt;
+
+import PetMoa.PetMoa.domain.user.entity.Role;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * JWT 토큰에서 추출한 사용자 정보를 담는 Principal 객체
+ * DB 조회 없이 인증 정보를 제공
+ */
+@Getter
+@RequiredArgsConstructor
+public class JwtUserPrincipal {
+
+    private final Long id;
+    private final String email;
+    private final Role role;
+
+    public static JwtUserPrincipal of(Long id, String email, Role role) {
+        return new JwtUserPrincipal(id, email, role);
+    }
+}

--- a/src/main/java/PetMoa/PetMoa/global/security/jwt/RefreshTokenService.java
+++ b/src/main/java/PetMoa/PetMoa/global/security/jwt/RefreshTokenService.java
@@ -1,0 +1,53 @@
+package PetMoa.PetMoa.global.security.jwt;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RBucket;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenService {
+
+    private final RedissonClient redissonClient;
+    private final JwtProperties jwtProperties;
+
+    private static final String REFRESH_TOKEN_PREFIX = "refresh_token:";
+
+    // Refresh Token 저장
+    public void saveRefreshToken(Long userId, String refreshToken) {
+        String key = REFRESH_TOKEN_PREFIX + userId;
+        RBucket<String> bucket = redissonClient.getBucket(key);
+
+        long expiryMillis = jwtProperties.getRefreshTokenExpiry();
+        bucket.set(refreshToken, Duration.ofMillis(expiryMillis));
+
+        log.debug("Refresh token saved for userId: {}", userId);
+    }
+
+    // Refresh Token 조회
+    public String getRefreshToken(Long userId) {
+        String key = REFRESH_TOKEN_PREFIX + userId;
+        RBucket<String> bucket = redissonClient.getBucket(key);
+        return bucket.get();
+    }
+
+    // Refresh Token 삭제 (로그아웃)
+    public void deleteRefreshToken(Long userId) {
+        String key = REFRESH_TOKEN_PREFIX + userId;
+        RBucket<String> bucket = redissonClient.getBucket(key);
+        bucket.delete();
+
+        log.debug("Refresh token deleted for userId: {}", userId);
+    }
+
+    // Refresh Token 검증
+    public boolean validateRefreshToken(Long userId, String refreshToken) {
+        String storedToken = getRefreshToken(userId);
+        return storedToken != null && storedToken.equals(refreshToken);
+    }
+}

--- a/src/main/java/PetMoa/PetMoa/global/security/jwt/TokenResponse.java
+++ b/src/main/java/PetMoa/PetMoa/global/security/jwt/TokenResponse.java
@@ -1,0 +1,20 @@
+package PetMoa.PetMoa.global.security.jwt;
+
+import lombok.Builder;
+
+@Builder
+public record TokenResponse(
+        String accessToken,
+        String refreshToken,
+        String tokenType,
+        long expiresIn
+) {
+    public static TokenResponse of(String accessToken, String refreshToken, long expiresIn) {
+        return TokenResponse.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .tokenType("Bearer")
+                .expiresIn(expiresIn)
+                .build();
+    }
+}

--- a/src/main/java/PetMoa/PetMoa/global/security/oauth2/CustomOAuth2User.java
+++ b/src/main/java/PetMoa/PetMoa/global/security/oauth2/CustomOAuth2User.java
@@ -1,0 +1,42 @@
+package PetMoa.PetMoa.global.security.oauth2;
+
+import PetMoa.PetMoa.domain.user.entity.User;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * OAuth2 인증된 사용자 정보를 담는 클래스
+ */
+@Getter
+public class CustomOAuth2User implements OAuth2User {
+
+    private final User user;
+    private final Map<String, Object> attributes;
+
+    public CustomOAuth2User(User user, Map<String, Object> attributes) {
+        this.user = user;
+        this.attributes = attributes;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singletonList(
+                new SimpleGrantedAuthority("ROLE_" + user.getRole().name()));
+    }
+
+    @Override
+    public String getName() {
+        return String.valueOf(user.getId());
+    }
+}

--- a/src/main/java/PetMoa/PetMoa/global/security/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/PetMoa/PetMoa/global/security/oauth2/CustomOAuth2UserService.java
@@ -1,0 +1,85 @@
+package PetMoa.PetMoa.global.security.oauth2;
+
+import PetMoa.PetMoa.domain.user.entity.AuthProvider;
+import PetMoa.PetMoa.domain.user.entity.Role;
+import PetMoa.PetMoa.domain.user.entity.User;
+import PetMoa.PetMoa.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+
+/**
+ * OAuth2 로그인 시 사용자 정보를 처리하는 서비스
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    @Transactional
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+
+        if ("kakao".equals(registrationId)) {
+            return processKakaoUser(oAuth2User);
+        }
+
+        throw new OAuth2AuthenticationException("지원하지 않는 소셜 로그인입니다: " + registrationId);
+    }
+
+    private OAuth2User processKakaoUser(OAuth2User oAuth2User) {
+        Map<String, Object> attributes = oAuth2User.getAttributes();
+
+        // 카카오 사용자 정보 추출
+        String providerId = String.valueOf(attributes.get("id"));
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
+
+        String nickname = (String) profile.get("nickname");
+        String email = (String) kakaoAccount.get("email");
+
+        log.debug("Kakao user info - providerId: {}, nickname: {}, email: {}",
+                providerId, nickname, email);
+
+        // 기존 사용자 조회 또는 신규 생성
+        User user = userRepository.findByProviderAndProviderId(AuthProvider.KAKAO, providerId)
+                .orElseGet(() -> createNewUser(providerId, nickname, email));
+
+        // 기존 사용자라면 프로필 업데이트
+        if (user.getId() != null) {
+            user.updateSocialProfile(nickname, email);
+        }
+
+        return new CustomOAuth2User(user, attributes);
+    }
+
+    private User createNewUser(String providerId, String nickname, String email) {
+        log.info("Creating new user - providerId: {}, nickname: {}", providerId, nickname);
+
+        User newUser = User.builder()
+                .name(nickname)
+                .email(email)
+                .provider(AuthProvider.KAKAO)
+                .providerId(providerId)
+                .role(Role.USER)
+                .build();
+
+        return userRepository.save(newUser);
+    }
+}

--- a/src/main/java/PetMoa/PetMoa/global/security/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/PetMoa/PetMoa/global/security/oauth2/CustomOAuth2UserService.java
@@ -57,14 +57,13 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         log.debug("Kakao user info - providerId: {}, nickname: {}, email: {}",
                 providerId, nickname, email);
 
-        // 기존 사용자 조회 또는 신규 생성
+        // 기존 사용자 업데이트 또는 신규 생성
         User user = userRepository.findByProviderAndProviderId(AuthProvider.KAKAO, providerId)
+                .map(existingUser -> {
+                    existingUser.updateSocialProfile(nickname, email);
+                    return existingUser;
+                })
                 .orElseGet(() -> createNewUser(providerId, nickname, email));
-
-        // 기존 사용자라면 프로필 업데이트
-        if (user.getId() != null) {
-            user.updateSocialProfile(nickname, email);
-        }
 
         return new CustomOAuth2User(user, attributes);
     }

--- a/src/main/java/PetMoa/PetMoa/global/security/oauth2/OAuth2AuthenticationFailureHandler.java
+++ b/src/main/java/PetMoa/PetMoa/global/security/oauth2/OAuth2AuthenticationFailureHandler.java
@@ -1,0 +1,35 @@
+package PetMoa.PetMoa.global.security.oauth2;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+
+/**
+ * OAuth2 로그인 실패 시 에러를 프론트엔드로 전달
+ */
+@Slf4j
+@Component
+public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationFailureHandler {
+
+    @Value("${app.oauth2.redirect-uri:http://localhost:3000/oauth/callback}")
+    private String redirectUri;
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
+                                        AuthenticationException exception) throws IOException {
+        log.error("OAuth2 authentication failed: {}", exception.getMessage());
+
+        String targetUrl = UriComponentsBuilder.fromUriString(redirectUri)
+                .queryParam("error", exception.getLocalizedMessage())
+                .build().toUriString();
+
+        getRedirectStrategy().sendRedirect(request, response, targetUrl);
+    }
+}

--- a/src/main/java/PetMoa/PetMoa/global/security/oauth2/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/PetMoa/PetMoa/global/security/oauth2/OAuth2AuthenticationSuccessHandler.java
@@ -1,6 +1,7 @@
 package PetMoa.PetMoa.global.security.oauth2;
 
 import PetMoa.PetMoa.domain.user.entity.User;
+import PetMoa.PetMoa.global.security.jwt.CookieUtils;
 import PetMoa.PetMoa.global.security.jwt.JwtTokenProvider;
 import PetMoa.PetMoa.global.security.jwt.RefreshTokenService;
 import jakarta.servlet.http.HttpServletRequest;
@@ -11,12 +12,11 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
-import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
 
 /**
- * OAuth2 로그인 성공 시 JWT 토큰을 발급하고 프론트엔드로 리다이렉트
+ * OAuth2 로그인 성공 시 JWT 토큰을 HttpOnly 쿠키로 설정하고 프론트엔드로 리다이렉트
  */
 @Slf4j
 @Component
@@ -25,6 +25,7 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
 
     private final JwtTokenProvider jwtTokenProvider;
     private final RefreshTokenService refreshTokenService;
+    private final CookieUtils cookieUtils;
 
     @Value("${app.oauth2.redirect-uri:http://localhost:3000/oauth/callback}")
     private String redirectUri;
@@ -42,14 +43,13 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
         // Refresh Token Redis 저장
         refreshTokenService.saveRefreshToken(user.getId(), refreshToken);
 
-        log.info("OAuth2 login success - userId: {}, name: {}", user.getId(), user.getName());
+        // HttpOnly 쿠키로 토큰 설정
+        cookieUtils.addAccessTokenCookie(response, accessToken);
+        cookieUtils.addRefreshTokenCookie(response, refreshToken);
 
-        // 프론트엔드로 리다이렉트 (토큰을 쿼리 파라미터로 전달)
-        String targetUrl = UriComponentsBuilder.fromUriString(redirectUri)
-                .queryParam("accessToken", accessToken)
-                .queryParam("refreshToken", refreshToken)
-                .build().toUriString();
+        // log.info("OAuth2 login success - userId: {}, name: {}", user.getId(), user.getName());
 
-        getRedirectStrategy().sendRedirect(request, response, targetUrl);
+        // 프론트엔드로 리다이렉트 (토큰은 쿠키로 전달되므로 쿼리 파라미터 불필요)
+        getRedirectStrategy().sendRedirect(request, response, redirectUri);
     }
 }

--- a/src/main/java/PetMoa/PetMoa/global/security/oauth2/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/PetMoa/PetMoa/global/security/oauth2/OAuth2AuthenticationSuccessHandler.java
@@ -1,0 +1,55 @@
+package PetMoa.PetMoa.global.security.oauth2;
+
+import PetMoa.PetMoa.domain.user.entity.User;
+import PetMoa.PetMoa.global.security.jwt.JwtTokenProvider;
+import PetMoa.PetMoa.global.security.jwt.RefreshTokenService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+
+/**
+ * OAuth2 로그인 성공 시 JWT 토큰을 발급하고 프론트엔드로 리다이렉트
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenService refreshTokenService;
+
+    @Value("${app.oauth2.redirect-uri:http://localhost:3000/oauth/callback}")
+    private String redirectUri;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+                                        Authentication authentication) throws IOException {
+        CustomOAuth2User oAuth2User = (CustomOAuth2User) authentication.getPrincipal();
+        User user = oAuth2User.getUser();
+
+        // JWT 토큰 생성
+        String accessToken = jwtTokenProvider.createAccessToken(user);
+        String refreshToken = jwtTokenProvider.createRefreshToken(user);
+
+        // Refresh Token Redis 저장
+        refreshTokenService.saveRefreshToken(user.getId(), refreshToken);
+
+        log.info("OAuth2 login success - userId: {}, name: {}", user.getId(), user.getName());
+
+        // 프론트엔드로 리다이렉트 (토큰을 쿼리 파라미터로 전달)
+        String targetUrl = UriComponentsBuilder.fromUriString(redirectUri)
+                .queryParam("accessToken", accessToken)
+                .queryParam("refreshToken", refreshToken)
+                .build().toUriString();
+
+        getRedirectStrategy().sendRedirect(request, response, targetUrl);
+    }
+}


### PR DESCRIPTION
## 📋 작업 내용
- 기존 X-User-Id 헤더 기반 임시 인증을 카카오 OAuth2 + JWT 구조로 전환했습니다.  
  - Spring Security + OAuth2 Client를 활용한 카카오 소셜 로그인 구현               
  - JWT Access Token(30분) + Refresh Token(7일, Redis 저장) 전략 적용
  - Refresh Token Rotation으로 보안 강화
  - 16개 API 엔드포인트에 @CurrentUser 어노테이션 적용

## 🎯 관련 이슈
- closes #18 

## 📝 변경 사항
  - [x] Spring Security + OAuth2 Client 설정 (SecurityConfig.java)
  - [x] JWT 토큰 발급/검증 (JwtTokenProvider.java, JwtAuthenticationFilter.java)
  - [x] Refresh Token Redis 저장 (RefreshTokenService.java)
  - [x] 카카오 OAuth2 로그인 핸들러 (CustomOAuth2UserService.java,
  OAuth2AuthenticationSuccessHandler.java)
  - [x] 인증 API 구현 (AuthController.java - 토큰 갱신, 로그아웃)
  - [x] User 엔티티 확장 (provider, providerId, role 필드 추가)
  - [x] Controller 마이그레이션 (@CurrentUser 어노테이션 적용)

## 📸 스크린샷 (선택사항)
- 필요한 경우 스크린샷 첨부

## ✅ 체크리스트
- [x] 코드 컨벤션 준수
- [x] 주석 작성
- [x] 문서 업데이트